### PR TITLE
Curve Refactoring for NN Torch Model

### DIFF
--- a/core/src/autogluon/core/models/abstract/abstract_model.py
+++ b/core/src/autogluon/core/models/abstract/abstract_model.py
@@ -1099,52 +1099,62 @@ class AbstractModel:
         return path
 
 
-    def save_curves(self, model, metric, training_curve, validation_curve, path: str = None):
+    def save_curves(self, metrics, train_curves, val_curves, path: str = None):
         """
         Saves learning curves to disk.
 
         Parameters
         ----------
-        model : str
-            Name of the iterative model that generated the curves
-        metric : str
-            Name of the evaluation metric used at each iteration of the curve
-        training_curve : list(float)
-            List of evaluation metrics computed at each iteration on the training dataset
-        validation_curve : list(float)
-            List of evaluation metrics computed at each iteration on the validation dataset
+        metrics : list(str)
+            List of all evaluation metrics computed at each iteration of the curve
+        training_curve : dict(str : list(float))
+            Dictionary of evaluation metrics computed at each iteration on the training dataset
+        validation_curve : dict(str : list(float))
+            Dictionary of evaluation metrics computed at each iteration on the validation dataset
+
+        e.g.
+                {
+                    'logloss': [0.693147, 0.690162, ...],
+                    'accuracy': [0.500000, 0.400000, ...],
+                    'f1': [0.693147, 0.690162, ...]
+                }
+
         path : str, default None
-            Path to the saved learning curves, minus the file name.
+            Path where the learning curves are saved, minus the file name.
             This should generally be a directory path ending with a '/' character (or appropriate path separator value depending on OS).
             If None, self.path is used.
-            The final curve file is typically saved to os.path.join(path, learning_curve_{MODELNAME}.json).
+            The final curve file is typically saved to os.path.join(path, curves.json).
 
         Returns
         -------
         path : str
             Path to the saved model, minus the file name.
         """
-
         if path is None:
             path = self.path
 
         os.makedirs(path, exist_ok=True)
-        file_path = os.path.join(path, f"learning_curves_{model}.json")
+        file_path = os.path.join(path, f"curves.json")
 
-        curves = {
-            model : {
+        curves = [
+            [ metrics ],
+            [
                 # iteration data goes here
-            }
-        }
+            ]
+        ]
 
-        for i in range(len(training_curve)):
-            curves[model][i] = {
-                metric : {
-                    "train": training_curve[i],
-                    "val": validation_curve[i],
-                    # "test": training_curve[i], # TODO: implement test curve data
-                }
-            }
+        iterations = 0
+        if len(metrics) > 0:
+            iterations = len(train_curves[metrics[0]])
+
+        for i in range(iterations):
+            curves[1].append([])
+            for metric in metrics:
+                curves[1][i].append([
+                        train_curves[metric][i], # "train": 
+                        val_curves[metric][i], # "val": 
+                        # "test": test_curves[metric][i], # TODO: implement test curve data
+                    ])
 
         with open(file_path, 'w') as json_file:
             json.dump(curves, json_file, indent=4)

--- a/core/src/autogluon/core/models/abstract/abstract_model.py
+++ b/core/src/autogluon/core/models/abstract/abstract_model.py
@@ -1137,7 +1137,7 @@ class AbstractModel:
         file_path = os.path.join(path, f"curves.json")
 
         curves = [
-            [ metrics ],
+            metrics,
             [
                 # iteration data goes here
             ]

--- a/core/src/autogluon/core/models/abstract/abstract_model.py
+++ b/core/src/autogluon/core/models/abstract/abstract_model.py
@@ -2104,6 +2104,16 @@ class AbstractModel:
 
         Possible params:
 
+        generate_curves : bool
+            boolean flag determining if learning curves should be saved to disk for iterative learners.
+        
+        curve_metrics : list(...)
+            list of metrics to be evaluated at each iteration of the learning curves 
+            (only used if generate_curves is True)
+
+        use_error_for_curve_metrics : bool
+            boolean flag determining if learning curve metrics should be displayed in error format (see Scorer class)
+        
         early_stop : int, str, or tuple
             generic name for early stopping logic. Typically can be an int or a str preset/strategy.
             Also possible to pass tuple of (class, kwargs) to construct a custom early stopping object.

--- a/tabular/src/autogluon/tabular/models/catboost/callbacks.py
+++ b/tabular/src/autogluon/tabular/models/catboost/callbacks.py
@@ -147,6 +147,11 @@ class EarlyStoppingCallback:
 
     def after_iteration(self, info):
         is_best_iter = False
+        # when calculating metrics for multiple "validation" datasets in CatBoost, validation is not
+        # a valid key, validation keys are named validation_0, validation_1, ...
+        if self.compare_key not in info.metrics:
+            self.compare_key = "validation_0"
+
         if self.is_quantile:
             # FIXME: CatBoost adds extra ',' in the metric name if quantile levels are not balanced
             # e.g., 'MultiQuantile:alpha=0.1,0.25,0.5,0.95' becomes 'MultiQuantile:alpha=0.1,,0.25,0.5,0.95'

--- a/tabular/src/autogluon/tabular/models/tabular_nn/torch/tabular_nn_torch.py
+++ b/tabular/src/autogluon/tabular/models/tabular_nn/torch/tabular_nn_torch.py
@@ -13,6 +13,7 @@ from autogluon.common.features.types import R_BOOL, R_CATEGORY, R_FLOAT, R_INT, 
 from autogluon.common.utils.pandas_utils import get_approximate_df_mem_usage
 from autogluon.common.utils.resource_utils import ResourceManager
 from autogluon.common.utils.try_import import try_import_torch
+from autogluon.core import metrics
 from autogluon.core.constants import BINARY, MULTICLASS, QUANTILE, REGRESSION, SOFTCLASS
 from autogluon.core.hpo.constants import RAY_BACKEND
 from autogluon.core.models.abstract.abstract_nn_model import AbstractNeuralNetworkModel
@@ -233,7 +234,7 @@ class TabularNeuralNetTorchModel(AbstractNeuralNetworkModel):
         if not os.path.exists(self.path):
             os.makedirs(self.path)
 
-    def _train_net(self, train_dataset, loss_kwargs, batch_size, num_epochs, epochs_wo_improve, val_dataset=None, time_limit=None, reporter=None, verbosity=2):
+    def _train_net(self, train_dataset, loss_kwargs, batch_size, num_epochs, epochs_wo_improve, val_dataset=None, time_limit=None, reporter=None, verbosity=2, generate_curves=False):
         import torch
 
         start_time = time.time()
@@ -244,6 +245,13 @@ class TabularNeuralNetTorchModel(AbstractNeuralNetworkModel):
 
         if isinstance(loss_kwargs.get("loss_function", "auto"), str) and loss_kwargs.get("loss_function", "auto") == "auto":
             loss_kwargs["loss_function"] = self._get_default_loss_function()
+
+        if generate_curves:
+            y_train = train_dataset.get_labels()
+            if y_train.ndim == 2 and y_train.shape[1] == 1:
+                y_train = y_train.flatten()
+        else:
+            y_train = None
 
         if val_dataset is not None:
             y_val = val_dataset.get_labels()
@@ -296,10 +304,14 @@ class TabularNeuralNetTorchModel(AbstractNeuralNetworkModel):
             time_limit = time_limit - (start_fit_time - start_time)
             if time_limit <= 0:
                 raise TimeLimitExceeded
-        generate_learning_curves = True
-        if generate_learning_curves:
-            train_learning_curve = []
-            validation_learning_curve = []
+        # if generate_curves:
+        stopping_metrics = [
+            metrics.get_metric("accuracy", self.problem_type, "eval_metric"),
+            metrics.get_metric("log_loss", self.problem_type, "eval_metric")
+            ]
+        train_curves = { metric.name : [] for metric in stopping_metrics }
+        val_curves = { metric.name : [] for metric in stopping_metrics }
+        # test_curves = { metric.name : [] for metric in stopping_metrics } # TODO: add test here
         while do_update:
             time_start_epoch = time.time()
             time_cur = time_start_epoch
@@ -348,11 +360,8 @@ class TabularNeuralNetTorchModel(AbstractNeuralNetworkModel):
 
             epoch += 1
 
-            # validation
-            if val_dataset is not None:
-                # compute validation score
-                val_metric = self.score(X=val_dataset, y=y_val, metric=self.stopping_metric, _reset_threads=False)
-                if np.isnan(val_metric):
+            def _assert_valid_metric(metric):
+                if np.isnan(metric):
                     if best_epoch == 0:
                         raise RuntimeError(
                             f"NaNs encountered in {self.__class__.__name__} training. "
@@ -361,7 +370,16 @@ class TabularNeuralNetTorchModel(AbstractNeuralNetworkModel):
                         )
                     else:
                         logger.warning(f"Warning: NaNs encountered in {self.__class__.__name__} training. " "Reverting model to last checkpoint without NaNs.")
-                        break
+                        return False
+                return True
+
+            # validation
+            if val_dataset is not None:
+                # compute validation score
+                val_metric = self.score(X=val_dataset, y=y_val, metric=self.stopping_metric, _reset_threads=False)
+
+                if not _assert_valid_metric(val_metric):
+                    break
 
                 # update best validation
                 if (val_metric >= best_val_metric) or best_epoch == 0:
@@ -372,11 +390,6 @@ class TabularNeuralNetTorchModel(AbstractNeuralNetworkModel):
                     torch.save(self.model, net_filename)
                     best_epoch = epoch
                     best_val_update = total_updates
-                
-                # update learning curve
-                if generate_learning_curves:
-                    train_learning_curve.append(total_train_loss / total_train_size, 4)
-                    validation_learning_curve.append(-val_metric, 4)
 
                 if verbose_eval:
                     logger.log(
@@ -400,6 +413,32 @@ class TabularNeuralNetTorchModel(AbstractNeuralNetworkModel):
                 if epoch - val_improve_epoch >= epochs_wo_improve:
                     break
 
+            # learning curve generation
+            if generate_curves:
+                train_metrics = []
+                val_metrics = []
+                test_metrics = []
+
+                stop = False
+                for metric in stopping_metrics:
+                    train_metrics.append(self.score(X=train_dataset, y=y_train, metric=metric, _reset_threads=False))
+                    val_metrics.append(self.score(X=val_dataset, y=y_val, metric=metric, _reset_threads=False))
+                    # test_metrics.append(...)
+                    if not _assert_valid_metric(train_metrics[-1]) or \
+                        not _assert_valid_metric(val_metrics[-1]): # or \
+                        # not _assert_valid_metric(test_metrics[-1]):
+                        stop = True
+                        break
+
+                if stop:
+                    break
+
+                # update learning curve
+                for i, metric in enumerate(stopping_metrics):
+                    train_curves[metric.name].append(train_metrics[i])
+                    val_curves[metric.name].append(val_metrics[i])
+                    # test_curves[metric.name].append(test_metrics[i])
+
             if epoch >= num_epochs:
                 break
 
@@ -414,8 +453,9 @@ class TabularNeuralNetTorchModel(AbstractNeuralNetworkModel):
         if epoch == 0:
             raise AssertionError("0 epochs trained!")
 
-        if generate_learning_curves:
-            self.save_curves(self.__class__.__name__, self.eval_metric.name, train_learning_curve, validation_learning_curve)
+        if generate_curves:
+            metric_names = [m.name for m in stopping_metrics]
+            self.save_curves(metric_names, train_curves, val_curves)
 
         # revert back to best model
         if val_dataset is not None:

--- a/tabular/src/autogluon/tabular/models/tabular_nn/torch/tabular_nn_torch.py
+++ b/tabular/src/autogluon/tabular/models/tabular_nn/torch/tabular_nn_torch.py
@@ -296,6 +296,10 @@ class TabularNeuralNetTorchModel(AbstractNeuralNetworkModel):
             time_limit = time_limit - (start_fit_time - start_time)
             if time_limit <= 0:
                 raise TimeLimitExceeded
+        generate_learning_curves = True
+        if generate_learning_curves:
+            train_learning_curve = []
+            validation_learning_curve = []
         while do_update:
             time_start_epoch = time.time()
             time_cur = time_start_epoch
@@ -368,6 +372,12 @@ class TabularNeuralNetTorchModel(AbstractNeuralNetworkModel):
                     torch.save(self.model, net_filename)
                     best_epoch = epoch
                     best_val_update = total_updates
+                
+                # update learning curve
+                if generate_learning_curves:
+                    train_learning_curve.append(total_train_loss / total_train_size, 4)
+                    validation_learning_curve.append(-val_metric, 4)
+
                 if verbose_eval:
                     logger.log(
                         15,
@@ -403,6 +413,9 @@ class TabularNeuralNetTorchModel(AbstractNeuralNetworkModel):
 
         if epoch == 0:
             raise AssertionError("0 epochs trained!")
+
+        if generate_learning_curves:
+            self.save_curves(self.__class__.__name__, self.eval_metric.name, train_learning_curve, validation_learning_curve)
 
         # revert back to best model
         if val_dataset is not None:

--- a/tabular/src/autogluon/tabular/models/xgboost/xgboost_model.py
+++ b/tabular/src/autogluon/tabular/models/xgboost/xgboost_model.py
@@ -148,7 +148,8 @@ class XGBoostModel(AbstractModel):
         if generate_curves and params["eval_metric"] is not None:
             main = params["eval_metric"]
             params["eval_metric"] = ['error', 'auc']
-            params["eval_metric"].remove(main)
+            if main in params["eval_metric"]:
+                params["eval_metric"].remove(main)
             params["eval_metric"].append(main)
 
         from xgboost import XGBClassifier, XGBRegressor


### PR DESCRIPTION
### Learning Curve Generation for PyTorch Neural Network Model

#### Summary of Changes

This pull request introduces enhancements to the AutoGluon framework to support the generation and saving of learning curves during model training. Key modifications include updates to training functions in specific model classes to enable iterative learning curve computation.

#### Detailed Changes

1. **TabularNeuralNetTorchModel Class (`TabularNeuralNetTorchModel`):**
   - Enhanced the `_fit()` function to generate learning curves:
     - **Purpose:** Integrated support for iteratively computing learning curves during each epoch of model training.
     - **Functionality:** Computes metrics across multiple datasets (train & validation).

2. **Integration and Usage:**
   - **Modularity:** Introduced ag hyperparameters such as `generating_curves` boolean flag and `curve_metrics` list:
     - **Purpose:** Allows toggling of the learning curve generation functionality.
     - **Functionality:** Ensures that AutoGluon's performance overhead is minimized when learning curve computation is not required.

3. **Post-Training Actions:**
   - After training completes, the `save_curves()` function is called and saves the generated learning curves.

#### Impact

- **Enhanced Monitoring:** Provides detailed insights into model performance across epochs and datasets.
- **Usability:** Allows users to toggle learning curve generation based on specific needs, enhancing efficiency and flexibility.

#### Results
When running the models with the `generate_curves` flag set to `True`, learning curves across several metrics are outputted to the model directory below in the following space-optimized format:

<img width="356" alt="Screenshot 2024-06-25 at 4 58 18 PM" src="https://github.com/adibiasio/autogluon/assets/61572112/57df776b-0f72-465c-a009-9e1360cf4192">


```

[
    [
        "mean_squared_error",
        "r2",
        "median_absolute_error",
        "root_mean_squared_error"
    ],
    [
        [
            [
                112.33439636230469,      # train mean_squared_error
                110.4916000366211        # validation mean_squared_error
            ],
            [
                0.5962829999410383,      # train r2
                0.5962985740859774       # validation r2
            ],
            [
                6.324695587158203,       # train median_absolute_error
                6.290250778198242        # validation median_absolute_error
            ],
            [
                10.59879207611084,       # train root_mean_squared_error
                10.51149845123291        # validation root_mean_squared_error
            ]
        ],
        [
            [
                105.73052215576172,
                106.07782745361328
            ],
            [
                0.5612289688081681,
                0.5724784184460979
            ],
            [
                6.087898254394531,
                6.124092102050781
            ],
            [
                10.2825345993042,
                10.299408912658691
            ]
        ],
        ...
    ]
]
```