### PR TITLE
Incorporating Learning Curve Functionality into Tabular Predictor

### DIFF
--- a/core/src/autogluon/core/constants.py
+++ b/core/src/autogluon/core/constants.py
@@ -34,6 +34,14 @@ LARGE_DATA_THRESHOLD = 1000
 REGRESS_THRESHOLD_LARGE_DATA = 0.05
 REGRESS_THRESHOLD_SMALL_DATA = 0.1
 
+# Models that currently support learning curve generation
+LEARNING_CURVE_SUPPORTED_MODELS = ["XGB", "NN_TORCH", "GBM"]
+DEFAULT_LEARNING_CURVE_METRICS = {
+    BINARY: ["log_loss", "accuracy", "precision", "recall", "f1", "roc_auc"],
+    REGRESSION: ['root_mean_squared_error', 'mean_squared_error', 'mean_absolute_error', 'median_absolute_error', 'r2'],
+    MULTICLASS: ["accuracy", "precision_weighted", "recall_weighted", "f1_weighted"],
+}
+
 # TODO: Add docs to dedicated page, or should it live in AbstractModel?
 # TODO: How to reference correct version of docs?
 # TODO: Add error in AG_ARGS if unknown key present


### PR DESCRIPTION
### Incorporating Learning Curve Functionality into Tabular Predictor

#### Summary of Changes

This pull request introduces enhancements to the AutoGluon framework to support the generation and saving of learning curves during model training. Key modifications include the creation of a `learning_curves` flag in predictor.fit where the user can determine whether to generate learning curves during training and also specify for which metrics and their format (error or score).

#### Detailed Changes

1. **Predictor Class:** 
    - **`fit()`:** Created learning_curves kwarg parameter, supporting either boolean value to use default curve generation parameters or dict to allow the user to specify metrics and metric format.
    - **`learning_curves()`:** Fetches and aggregates learning curves generated for each model during training. This function will raise errors if predictor was not fit with appropriate learning_curve parameters.
    - **`_initialize_learning_curve_params()`:** Parses learning_curves param from predictor.fit and returns a hyperparameters dict in `ag_args` format.


#### Results
When running the models with the `learning_curves` argument in `predictor.fit`, the predictor will propogate `ag_params` reflecting these specifications downwards to the models, ultimately generating the desired curves. Call `predictor.learning_curves()` to access them. Sample learning_curves() output:

```
curves = {
    metadata,
    {
        "model": json from associated model's curves.json,
        "model": json from associated model's curves.json,
        "model": json from associated model's curves.json,
        "model": json from associated model's curves.json,
    }
}
```

Sample Usage:
```
import pandas as pd
from autogluon.tabular import TabularPredictor

train_data = pd.read_csv('https://autogluon.s3.amazonaws.com/datasets/Inc/train.csv')
test_data = pd.read_csv('https://autogluon.s3.amazonaws.com/datasets/Inc/test.csv')

predictor = TabularPredictor(
    label="age",
    problem_type="regression",
)

###### Simple Usage ######
predictor = predictor.fit(
    train_data=train_data,
    test_data=test_data,  # can specify whether to include test_data or not in curves here
    learning_curves=True, # initiates curve generation with default metrics for problem_type
)

##### Alternate Usage #####
curve_params = {
    "metrics": "r2", # or ["r2", "mean_absolute_error"]
    "use_error": True
}

predictor = predictor.fit(
    train_data=train_data,
    test_data=test_data,          # can specify whether to include test_data or not in curves here
    learning_curves=curve_params, # can specify what metrics to include and in what format (score or error)
)

curves = predictor.learning_curves()
```